### PR TITLE
Pathfinder Approved Enemy Spawning

### DIFF
--- a/Assets/Prefabs/Environment/Enemy.prefab
+++ b/Assets/Prefabs/Environment/Enemy.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 1319029063592873517}
   - component: {fileID: 2385301980652908376}
   - component: {fileID: 1547208417641009855}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Scenes/MAIN.unity
+++ b/Assets/Scenes/MAIN.unity
@@ -206,7 +206,7 @@ GameObject:
   - component: {fileID: 131810153}
   - component: {fileID: 131810152}
   - component: {fileID: 131810151}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (20)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -391,7 +391,7 @@ GameObject:
   - component: {fileID: 277643473}
   - component: {fileID: 277643472}
   - component: {fileID: 277643471}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -750,7 +750,7 @@ GameObject:
   - component: {fileID: 361402810}
   - component: {fileID: 361402809}
   - component: {fileID: 361402808}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -935,7 +935,7 @@ GameObject:
   - component: {fileID: 399804925}
   - component: {fileID: 399804924}
   - component: {fileID: 399804923}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1212,11 +1212,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 76d16499ea540eb44be4f56b74b94c27, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GridSize: {x: 100, y: 100}
-  GridOffset: {x: -2, y: -79}
+  MyMazeGrid: {fileID: 1538966079}
+  GridSize: {x: 402, y: 402}
+  GridOffset: {x: 0, y: -381}
   DefaultCellCost: 999
   FreeCellCost: 1
   NeighboringWallCellCost: 10
+  NeighboringWallMaxDist: 1
   ObstacleCost: 2
   CollisionMap: {fileID: 1292598294}
   isInitialized: 0
@@ -1240,7 +1242,7 @@ GameObject:
   - component: {fileID: 520359214}
   - component: {fileID: 520359215}
   - component: {fileID: 520359216}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Player
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1473,7 +1475,7 @@ GameObject:
   - component: {fileID: 531481671}
   - component: {fileID: 531481670}
   - component: {fileID: 531481669}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1658,7 +1660,7 @@ GameObject:
   - component: {fileID: 649407206}
   - component: {fileID: 649407205}
   - component: {fileID: 649407204}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1843,7 +1845,7 @@ GameObject:
   - component: {fileID: 762539933}
   - component: {fileID: 762539932}
   - component: {fileID: 762539931}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2101,7 +2103,7 @@ GameObject:
   - component: {fileID: 982097638}
   - component: {fileID: 982097637}
   - component: {fileID: 982097636}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2286,7 +2288,7 @@ GameObject:
   - component: {fileID: 1046897875}
   - component: {fileID: 1046897874}
   - component: {fileID: 1046897873}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2472,7 +2474,7 @@ GameObject:
   - component: {fileID: 1094830614}
   - component: {fileID: 1094830613}
   - component: {fileID: 1094830615}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -2673,7 +2675,7 @@ GameObject:
   - component: {fileID: 1121731068}
   - component: {fileID: 1121731067}
   - component: {fileID: 1121731066}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2857,7 +2859,7 @@ GameObject:
   - component: {fileID: 1292598293}
   - component: {fileID: 1292598295}
   - component: {fileID: 1292598296}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Tilemap
   m_TagString: Maze
   m_Icon: {fileID: 0}
@@ -3028,7 +3030,7 @@ GameObject:
   - component: {fileID: 1334904029}
   - component: {fileID: 1334904028}
   - component: {fileID: 1334904027}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3213,7 +3215,7 @@ GameObject:
   - component: {fileID: 1372392687}
   - component: {fileID: 1372392686}
   - component: {fileID: 1372392685}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3398,7 +3400,7 @@ GameObject:
   - component: {fileID: 1383138844}
   - component: {fileID: 1383138843}
   - component: {fileID: 1383138842}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (18)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3583,7 +3585,7 @@ GameObject:
   - component: {fileID: 1464565167}
   - component: {fileID: 1464565166}
   - component: {fileID: 1464565165}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3768,7 +3770,7 @@ GameObject:
   - component: {fileID: 1524321091}
   - component: {fileID: 1524321090}
   - component: {fileID: 1524321089}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (19)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3953,7 +3955,7 @@ GameObject:
   - component: {fileID: 1534821534}
   - component: {fileID: 1534821533}
   - component: {fileID: 1534821532}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4317,7 +4319,7 @@ GameObject:
   - component: {fileID: 1569374068}
   - component: {fileID: 1569374067}
   - component: {fileID: 1569374066}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4604,7 +4606,7 @@ GameObject:
   - component: {fileID: 1684254206}
   - component: {fileID: 1684254205}
   - component: {fileID: 1684254204}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4915,7 +4917,7 @@ GameObject:
   - component: {fileID: 2068817696}
   - component: {fileID: 2068817695}
   - component: {fileID: 2068817694}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5100,7 +5102,7 @@ GameObject:
   - component: {fileID: 2105139882}
   - component: {fileID: 2105139881}
   - component: {fileID: 2105139880}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Enemy (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -53,7 +53,6 @@ public class Enemy : MonoBehaviour
 
     public void Follow()
     {
-        //TODO: Implement Resource Saving Optimization for Bee-Line walking.
 
         if(!pathfinderAgent.isPathing())
         {

--- a/Assets/Scripts/Pathfinder.cs
+++ b/Assets/Scripts/Pathfinder.cs
@@ -57,6 +57,10 @@ public class Pathfinder : MonoBehaviour
         npos += Vector2Int.FloorToInt(transform.position);
         return npos;
     }
+    public bool isPosOk(Vector2 position)
+    {
+        return isPosInBounds(toPos(position))&&(grid.GetCellCost(toPos(position)) != float.PositiveInfinity);
+    }
     private bool isPosInBounds(RoyT.AStar.Position pos)
     {
         return ((pos.X >= 0 && pos.Y >= 1) && (pos.X < GridSize.x-1&& pos.Y < GridSize.y));


### PR DESCRIPTION
Enemies now can spawn only in pathfinder approved locations. I went into the Monster Spawning script and added the checks, and I also assigned proper layers to the tilemap in MAIN so pathfinding works in the scene again.